### PR TITLE
Simplify journal update output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ command line script.
 ## Usage
 
 ```
-python journal_updater/journal_updater.py BASE_DOCX CONTENT_FOLDER OUTPUT_DOCX
+python journal_updater/journal_updater.py BASE_DOCX CONTENT_FOLDER [OUTPUT_DOCX]
 ```
 
 - **BASE_DOCX**: path to the previous issue's Word file (e.g. December 2024).
@@ -32,7 +32,9 @@ python journal_updater/journal_updater.py BASE_DOCX CONTENT_FOLDER OUTPUT_DOCX
   include:
   - `president_message.txt` – new President's Message text.
   - `article*.docx` – Word documents for each new article.
-- **OUTPUT_DOCX**: path where the updated June issue should be saved.
+- **OUTPUT_DOCX** *(optional)*: path where the updated issue should be saved.
+  If omitted, the script writes the result next to `BASE_DOCX` with
+  `"_updated.docx"` appended to the name.
 
 The script performs a handful of automated replacements:
 

--- a/journal_updater/gui.py
+++ b/journal_updater/gui.py
@@ -23,21 +23,39 @@ def run_gui():
             selected_content.set(path)
 
     def choose_output():
-        path = filedialog.asksaveasfilename(title="Save output DOCX", defaultextension=".docx", filetypes=[("Word files", "*.docx")])
+        path = filedialog.asksaveasfilename(
+            title="Save output DOCX",
+            defaultextension=".docx",
+            filetypes=[("Word files", "*.docx")],
+        )
         if path:
             selected_output.set(path)
 
     def run_update():
-        if not selected_base.get() or not selected_content.get() or not selected_output.get():
-            messagebox.showerror("Missing information", "Please select all required paths")
+        if not selected_base.get() or not selected_content.get():
+            messagebox.showerror(
+                "Missing information",
+                "Please select a base DOCX and content folder",
+            )
             return
         try:
+            output_arg = Path(selected_output.get()) if selected_output.get() else None
             journal_updater.main_from_gui(
                 Path(selected_base.get()),
                 Path(selected_content.get()),
-                Path(selected_output.get()),
+                output_arg,
             )
-            messagebox.showinfo("Success", "Journal updated successfully")
+            final_path = (
+                output_arg
+                if output_arg is not None
+                else Path(selected_base.get()).with_name(
+                    Path(selected_base.get()).stem + "_updated.docx"
+                )
+            )
+            messagebox.showinfo(
+                "Success",
+                f"Journal updated successfully\nSaved to: {final_path}",
+            )
         except Exception as e:
             messagebox.showerror("Error", f"Failed to update journal: {e}")
 
@@ -50,7 +68,7 @@ def run_gui():
     tk.Button(frm, text="Choose Content Folder", command=choose_content).grid(row=1, column=0, sticky="ew")
     tk.Label(frm, textvariable=selected_content, width=40, anchor="w").grid(row=1, column=1, padx=5)
 
-    tk.Button(frm, text="Choose Output DOCX", command=choose_output).grid(row=2, column=0, sticky="ew")
+    tk.Button(frm, text="Choose Output DOCX (optional)", command=choose_output).grid(row=2, column=0, sticky="ew")
     tk.Label(frm, textvariable=selected_output, width=40, anchor="w").grid(row=2, column=1, padx=5)
 
     tk.Button(frm, text="Run Update", command=run_update).grid(row=3, column=0, columnspan=2, pady=5)

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -312,21 +312,43 @@ def update_journal(base_path: Path, content_path: Path, output_path: Path) -> No
     pdf_path = output_path.with_suffix(".pdf")
     save_pdf(output_path, pdf_path)
 
-def main_from_gui(base_doc: Path, content_folder: Path, output_doc: Path) -> None:
-    """Helper for GUI front-end."""
-    update_journal(base_doc, content_folder, output_doc)
+def main_from_gui(
+    base_doc: Path, content_folder: Path, output_doc: Optional[Path] = None
+) -> None:
+    """Helper for GUI front-end.
+
+    If ``output_doc`` is not provided, the resulting file will be saved next to
+    ``base_doc`` with ``_updated`` appended to the original file name.
+    """
+    target = (
+        output_doc
+        if output_doc is not None
+        else base_doc.with_name(base_doc.stem + "_updated.docx")
+    )
+    update_journal(base_doc, content_folder, target)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Update ABNFF Journal document")
     parser.add_argument("base_doc")
     parser.add_argument("content_folder")
-    parser.add_argument("output_doc")
+    parser.add_argument(
+        "output_doc",
+        nargs="?",
+        help=(
+            "Path to save the updated DOCX. Defaults to <base_doc> with "
+            "'_updated.docx' appended"
+        ),
+    )
     args = parser.parse_args()
 
     base_path = Path(args.base_doc)
     content_path = Path(args.content_folder)
-    output_path = Path(args.output_doc)
+    output_path = (
+        Path(args.output_doc)
+        if args.output_doc
+        else base_path.with_name(base_path.stem + "_updated.docx")
+    )
 
     update_journal(base_path, content_path, output_path)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -37,3 +37,18 @@ def test_update_page2_header(tmp_path):
     header_p.text = "Old header"
     journal_updater.update_page2_header(doc, "Volume 1", 2)
     assert "Page 2" in section.header.paragraphs[0].text
+
+
+def test_main_from_gui_default_output(tmp_path):
+    base_doc = tmp_path / "base.docx"
+    doc = journal_updater.Document()
+    doc.add_paragraph("Volume 1, Issue 1")
+    doc.save(base_doc)
+
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+
+    journal_updater.main_from_gui(base_doc, content_dir)
+
+    expected = base_doc.with_name(base_doc.stem + "_updated.docx")
+    assert expected.exists()


### PR DESCRIPTION
## Summary
- make output document optional for the CLI and GUI
- update README usage instructions
- save GUI output next to the base doc if no path is selected
- add test for default output behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee56c6bc8321bbeb6c4660da47b9