### PR TITLE
Add layout helper functions

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,10 @@
+# JournalAutomator Instructions
+
+This project provides various helper functions to automate updates to the ABNFF Journal. Each helper can be called individually from your own scripts.
+
+## Layout helpers
+
+- `apply_two_column_layout(doc, start_page)` – convert sections starting at `start_page` to a two‑column layout. The function relies on `Section.text_columns` where available and falls back to directly editing the XML.
+- `add_page_borders(doc, start_section)` – add simple left and right borders starting with the specified section.
+
+Use these helpers in combination with other utilities defined in `journal_updater.py` to customize your journal layout.

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -269,9 +269,81 @@ def update_table_of_contents(doc: Document) -> None:
     pass
 
 
+def apply_two_column_layout(doc: Document, start_page: int) -> None:
+    """Set sections starting at ``start_page`` to use two text columns."""
+
+    try:
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+    except Exception:
+        return
+
+    for idx, section in enumerate(doc.sections):
+        if idx + 1 < start_page:
+            continue
+
+        # Prefer new API if available
+        if hasattr(section, "text_columns"):
+            try:
+                section.text_columns.set_num(2)
+                section.text_columns.spacing = Pt(36)  # ensure a small gap
+            except Exception:
+                pass
+            continue
+
+        sectPr = section._sectPr
+        cols = sectPr.find(qn("w:cols"))
+        if cols is None:
+            cols = OxmlElement("w:cols")
+            cols.set(qn("w:space"), "720")
+            sectPr.append(cols)
+        cols.set(qn("w:num"), "2")
+
+
 def apply_page_borders(doc: Document, start_section: int, border_specs) -> None:
     """Apply borders to pages starting at ``start_section``."""
     pass
+
+
+def add_page_borders(doc: Document, start_section: int) -> None:
+    """Add solid left and right borders for sections from ``start_section``."""
+
+    try:
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+    except Exception:
+        return
+
+    for idx, section in enumerate(doc.sections):
+        if idx < start_section:
+            continue
+
+        if hasattr(section, "page_setup") and hasattr(section.page_setup, "left_border"):  # type: ignore[attr-defined]
+            try:
+                ps = section.page_setup
+                ps.left_border = ps.right_border = {
+                    "val": "single",
+                    "sz": 4,
+                    "space": 0,
+                    "color": "000000",
+                }
+                continue
+            except Exception:
+                pass
+
+        sectPr = section._sectPr
+        for existing in sectPr.findall(qn("w:pgBorders")):
+            sectPr.remove(existing)
+        pgBorders = OxmlElement("w:pgBorders")
+        pgBorders.set(qn("w:offsetFrom"), "text")
+        for side in ("left", "right"):
+            border = OxmlElement(f"w:{side}")
+            border.set(qn("w:val"), "single")
+            border.set(qn("w:sz"), "4")
+            border.set(qn("w:space"), "0")
+            border.set(qn("w:color"), "000000")
+            pgBorders.append(border)
+        sectPr.append(pgBorders)
 
 
 def validate_issue_number_and_volume(doc: Document, expected_volume: str, expected_issue: str, expected_year: str) -> None:


### PR DESCRIPTION
## Summary
- add apply_two_column_layout helper
- add add_page_borders helper
- document layout helpers in instructions.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f02767688321b7e32d57856c65f4