### PR TITLE
Improve article clearing with TOC titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ The script performs a handful of automated replacements:
 3. Updates page 2 header text.
 4. Inserts the President's Message from `president_message.txt`.
 5. Clears all old articles and appends the new ones found in the
-   content folder.
+   content folder. The removal step relies on article titles listed
+   under the **ARTICLES** section of the Table of Contents.
 6. Saves the resulting document and optionally attempts to export a PDF
    alongside it (requires `docx2pdf`).
+
+Ensure your base document includes a Table of Contents with an
+**ARTICLES** heading so article titles can be detected and removed.
 
 The implementation is intentionally minimal and serves as a starting
 point for further automation as outlined in the program goals.

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -114,7 +114,86 @@ def insert_presidents_message(doc: Document, image_path: Path, message_text: str
             break
 
 
+def extract_article_titles_from_toc(doc: Document) -> List[str]:
+    """Return article titles listed under the ARTICLES section in the TOC."""
+    toc_start = None
+    paragraphs = doc.paragraphs
+    # locate table of contents
+    for i, p in enumerate(paragraphs):
+        if "TABLE OF CONTENTS" in p.text.upper():
+            toc_start = i
+            break
+    if toc_start is None:
+        return []
+
+    # find ARTICLES heading within TOC
+    start = None
+    for j in range(toc_start + 1, len(paragraphs)):
+        text = paragraphs[j].text.strip()
+        if text.upper().startswith("ARTICLES"):
+            start = j + 1
+            break
+    if start is None:
+        return []
+
+    titles: List[str] = []
+    import re
+
+    for k in range(start, len(paragraphs)):
+        line = paragraphs[k].text.strip()
+        if not line:
+            break
+        if line.isupper():
+            break
+        match = re.match(r"(.+?)\.{2,}\d+$", line)
+        if match:
+            titles.append(match.group(1).strip())
+        else:
+            titles.append(line)
+
+    return titles
+
+
 def clear_articles(doc: Document):
+    """Remove article sections based on TOC titles if available."""
+    titles = extract_article_titles_from_toc(doc)
+
+    def remove_paragraph(paragraph):
+        p = paragraph._element
+        p.getparent().remove(p)
+
+    if titles:
+        article_heading_idx = None
+
+        # find start indices of each article title and detect the heading
+        start_indices = []
+        for title in titles:
+            for i, p in enumerate(doc.paragraphs):
+                if p.text.strip().upper() == title.upper():
+                    start_indices.append(i)
+                    if article_heading_idx is None and i > 0:
+                        prev = doc.paragraphs[i - 1].text.strip().upper()
+                        if prev == "ARTICLES":
+                            article_heading_idx = i - 1
+                    break
+        start_indices.sort()
+        if article_heading_idx is not None and (
+            not start_indices or article_heading_idx < start_indices[0]
+        ):
+            start_indices.insert(0, article_heading_idx)
+
+        for idx in reversed(range(len(start_indices))):
+            start = start_indices[idx]
+            end = (
+                start_indices[idx + 1]
+                if idx + 1 < len(start_indices)
+                else len(doc.paragraphs)
+            )
+            for _ in range(end - start):
+                remove_paragraph(doc.paragraphs[start])
+        return
+
+    # fallback to previous behaviour if we cannot parse TOC
     found = False
     start_idx = 0
     for i, p in enumerate(doc.paragraphs):
@@ -124,7 +203,7 @@ def clear_articles(doc: Document):
             break
     if found:
         for _ in range(len(doc.paragraphs) - start_idx):
-            doc.paragraphs.pop()
+            remove_paragraph(doc.paragraphs[start_idx])
 
 
 def append_article(doc: Document, article_doc: Document):

--- a/tests/test_clear_articles.py
+++ b/tests/test_clear_articles.py
@@ -1,0 +1,47 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import journal_updater.journal_updater as ju
+
+
+def _paragraph_texts(doc):
+    return [p.text for p in doc.paragraphs]
+
+
+def test_clear_articles_with_toc():
+    doc = ju.Document()
+    doc.add_paragraph("Table of Contents")
+    doc.add_paragraph("ARTICLES")
+    doc.add_paragraph("First Article........................1")
+    doc.add_paragraph("Second Article.......................5")
+    doc.add_paragraph("")
+    doc.add_paragraph("OTHER")
+
+    doc.add_paragraph("ARTICLES")
+    doc.add_paragraph("First Article")
+    doc.add_paragraph("f content")
+    doc.add_paragraph("Second Article")
+    doc.add_paragraph("s content")
+    doc.add_paragraph("OTHER")
+
+    ju.clear_articles(doc)
+    texts = _paragraph_texts(doc)
+    assert "First Article" not in texts
+    assert "Second Article" not in texts
+    assert "f content" not in texts
+    assert "s content" not in texts
+    assert texts[-1] == "OTHER"
+
+
+def test_clear_articles_fallback():
+    doc = ju.Document()
+    doc.add_paragraph("Intro")
+    doc.add_paragraph("ARTICLES")
+    doc.add_paragraph("Old text")
+    doc.add_paragraph("More")
+
+    ju.clear_articles(doc)
+    texts = _paragraph_texts(doc)
+    assert texts == ["Intro"]
+


### PR DESCRIPTION
## Summary
- add helper to parse article titles from the Table of Contents
- remove articles using titles when TOC available, falling back otherwise
- document the TOC requirement in README
- test article removal logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f0e159508321ae464bcfb0be3b1b