### PR TITLE
Support front/footer formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ control certain aspects of the update. Supported keys are:
 - `delete_after_page` – remove all content after this page number.
 - `font_size` – default font size to apply to all text (in points).
 - `line_spacing` – line spacing value (e.g. `1.0` or `1.15`).
+- `format_front_and_footer` – optional block with `font_size` and
+  `line_spacing` to style the front cover paragraph and all footers.
 
 Example file:
 
@@ -78,7 +80,11 @@ Example file:
   "issue": "3",
   "delete_after_page": 2,
   "font_size": 10,
-  "line_spacing": 1.0
+  "line_spacing": 1.0,
+  "format_front_and_footer": {
+    "font_size": 14,
+    "line_spacing": 1.2
+  }
 }
 ```
 

--- a/instructions.json
+++ b/instructions.json
@@ -1,4 +1,8 @@
 {
   "font_size": 12,
-  "line_spacing": 1.5
+  "line_spacing": 1.5,
+  "format_front_and_footer": {
+    "font_size": 14,
+    "line_spacing": 1.2
+  }
 }

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -213,7 +213,12 @@ def load_instructions(content_path: Path) -> dict:
     if inst_file.exists():
         try:
             with inst_file.open("r", encoding="utf-8") as f:
-                return json.load(f)
+                data = json.load(f)
+                if "format_front_and_footer" in data and not isinstance(
+                    data["format_front_and_footer"], dict
+                ):
+                    data["format_front_and_footer"] = {}
+                return data
         except Exception as e:
             print(f"Failed to read instructions: {e}")
     return {}
@@ -263,6 +268,32 @@ def set_line_spacing(doc: Document, start_paragraph: int, spacing: float) -> Non
     """Set line spacing for paragraphs starting at ``start_paragraph``."""
     for p in doc.paragraphs[start_paragraph:]:
         p.paragraph_format.line_spacing = spacing
+
+
+def format_front_and_footer(
+    doc: Document,
+    font_size: Optional[int] = None,
+    line_spacing: Optional[float] = None,
+) -> None:
+    """Apply formatting to the front cover block and all footers."""
+
+    # front cover paragraph usually contains "Volume" text
+    for p in doc.paragraphs:
+        if "Volume" in p.text:
+            if line_spacing is not None:
+                p.paragraph_format.line_spacing = line_spacing
+            if font_size is not None:
+                for run in p.runs:
+                    run.font.size = Pt(font_size)
+            break
+
+    for section in doc.sections:
+        for p in section.footer.paragraphs:
+            if line_spacing is not None:
+                p.paragraph_format.line_spacing = line_spacing
+            if font_size is not None:
+                for run in p.runs:
+                    run.font.size = Pt(font_size)
 
 def reuse_journal_page(doc: Document, source_doc: Document, page_number: int) -> None:
     """Copy the specified page from ``source_doc`` into ``doc``."""
@@ -504,12 +535,7 @@ def update_journal(
 ) -> None:
     """Run the update process with explicit paths and parameters."""
     doc = load_document(base_path)
-    instr_path = content_path / "instructions.json"
-    instructions = {}
-    if instr_path.exists():
-        import json
-
-        instructions = json.loads(instr_path.read_text())
+    instructions = load_instructions(content_path)
 
     update_front_cover(doc, volume, issue, month_year, section_title, cover_page_num)
     update_business_information(
@@ -533,6 +559,14 @@ def update_journal(
         set_font_size(doc, start_idx, int(instructions["font_size"]))
     if "line_spacing" in instructions:
         set_line_spacing(doc, start_idx, float(instructions["line_spacing"]))
+
+    fmt = instructions.get("format_front_and_footer", {})
+    if fmt:
+        format_front_and_footer(
+            doc,
+            font_size=fmt.get("font_size"),
+            line_spacing=fmt.get("line_spacing"),
+        )
 
     save_document(doc, output_path)
     pdf_path = output_path.with_suffix(".pdf")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -71,8 +71,30 @@ def test_update_journal_formatting(tmp_path):
     )
 
     out_path = tmp_path / "out.docx"
-    journal_updater.update_journal(base_path, content_dir, out_path)
+    journal_updater.update_journal(
+        base_path,
+        content_dir,
+        out_path,
+        "1",
+        "1",
+        "Jan 2024",
+        "Articles",
+    )
     result = journal_updater.Document(out_path)
 
-    assert result.paragraphs[1].runs[0].font.size.pt == 14
-    assert result.paragraphs[1].paragraph_format.line_spacing == 2
+    assert result.paragraphs[0].runs[0].font.size.pt == 14
+    assert result.paragraphs[0].paragraph_format.line_spacing == 2
+
+
+def test_format_front_and_footer(tmp_path):
+    doc = journal_updater.Document()
+    p = doc.add_paragraph("Volume 1")
+    footer_p = doc.sections[0].footer.paragraphs[0]
+    footer_p.text = "footer"
+
+    journal_updater.format_front_and_footer(doc, font_size=13, line_spacing=1.25)
+
+    assert p.runs[0].font.size.pt == 13
+    assert p.paragraph_format.line_spacing == 1.25
+    assert footer_p.runs[0].font.size.pt == 13
+    assert footer_p.paragraph_format.line_spacing == 1.25


### PR DESCRIPTION
## Summary
- add `format_front_and_footer` example to `instructions.json`
- document new block in README
- implement `format_front_and_footer()` helper and hook up in `update_journal`
- load instructions via `load_instructions`
- expand tests to cover new formatting options and updated `update_journal` call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430227dee88321905d83c73e40ada2