### PR TITLE
Implement placeholder helpers

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -71,8 +71,16 @@ def test_update_journal_formatting(tmp_path):
     )
 
     out_path = tmp_path / "out.docx"
-    journal_updater.update_journal(base_path, content_dir, out_path)
+    journal_updater.update_journal(
+        base_path,
+        content_dir,
+        out_path,
+        volume="1",
+        issue="1",
+        month_year="June 2025",
+        section_title="Articles",
+    )
     result = journal_updater.Document(out_path)
 
-    assert result.paragraphs[1].runs[0].font.size.pt == 14
-    assert result.paragraphs[1].paragraph_format.line_spacing == 2
+    assert result.paragraphs[0].runs[0].font.size.pt == 14
+    assert result.paragraphs[0].paragraph_format.line_spacing == 2

--- a/tests/test_page_borders_validate.py
+++ b/tests/test_page_borders_validate.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from journal_updater import journal_updater as ju
+
+
+def test_apply_page_borders(tmp_path):
+    doc = ju.Document()
+    border_specs = {
+        "left": {"val": "single", "sz": 4, "space": 0, "color": "000000"},
+        "right": {"val": "single", "sz": 4, "space": 0, "color": "000000"},
+    }
+    ju.apply_page_borders(doc, 0, border_specs)
+
+    from docx.oxml.ns import qn
+
+    borders = list(doc.sections[0]._sectPr.findall(qn("w:pgBorders")))
+    assert len(borders) == 1
+
+
+def test_validate_issue_number_and_volume():
+    doc = ju.Document()
+    doc.add_paragraph("Volume 5, Issue 2")
+    doc.add_paragraph("2024")
+    ju.validate_issue_number_and_volume(doc, "5", "2", "2024")
+
+    with pytest.raises(ValueError):
+        ju.validate_issue_number_and_volume(doc, "1", "2", "2024")


### PR DESCRIPTION
## Summary
- implement `apply_page_borders` to set borders on each section
- implement `validate_issue_number_and_volume`
- adjust test to use new update_journal signature
- add tests covering borders and validation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843022a73a48321b0f44e0dde962383