### PR TITLE
Fix assistant editor removal and update tests

### DIFF
--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -100,7 +100,10 @@ def update_assistant_editors(doc: Document, remove_name: str) -> None:
 
     for p in doc.paragraphs:
         if remove_name in p.text:
-            p.text = ""
+            elem = p._element
+            parent = elem.getparent()
+            parent.remove(elem)
+            break
 
 
 def insert_presidents_message(doc: Document, image_path: Path, message_text: str) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -71,8 +71,17 @@ def test_update_journal_formatting(tmp_path):
     )
 
     out_path = tmp_path / "out.docx"
-    journal_updater.update_journal(base_path, content_dir, out_path)
+    journal_updater.update_journal(
+        base_path,
+        content_dir,
+        out_path,
+        "1",
+        "1",
+        "June 2025",
+        "Articles",
+    )
     result = journal_updater.Document(out_path)
 
-    assert result.paragraphs[1].runs[0].font.size.pt == 14
-    assert result.paragraphs[1].paragraph_format.line_spacing == 2
+
+    assert result.paragraphs[0].runs[0].font.size.pt == 14
+    assert result.paragraphs[0].paragraph_format.line_spacing == 2

--- a/tests/test_update_assistant_editors.py
+++ b/tests/test_update_assistant_editors.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import journal_updater.journal_updater as ju
+
+
+def _paragraph_texts(doc):
+    return [p.text for p in doc.paragraphs]
+
+
+def test_update_assistant_editors_removes_line():
+    doc = ju.Document()
+    doc.add_paragraph("Assistant Editors")
+    doc.add_paragraph("Alice")
+    doc.add_paragraph("Bob")
+
+    ju.update_assistant_editors(doc, "Alice")
+    texts = _paragraph_texts(doc)
+    assert "Alice" not in texts
+    assert texts == ["Assistant Editors", "Bob"]
+    assert "" not in texts


### PR DESCRIPTION
## Summary
- remove matching assistant editor paragraph instead of leaving blank
- test the new update_assistant_editors behaviour
- adjust journal update formatting test for required arguments and font index
- restore font utils test indices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684302319c148321a4946ee833e9bf4b