### PR TITLE
Limit extra space cleanup by page

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -71,8 +71,16 @@ def test_update_journal_formatting(tmp_path):
     )
 
     out_path = tmp_path / "out.docx"
-    journal_updater.update_journal(base_path, content_dir, out_path)
+    journal_updater.update_journal(
+        base_path,
+        content_dir,
+        out_path,
+        volume="1",
+        issue="1",
+        month_year="June 2025",
+        section_title="Articles",
+    )
     result = journal_updater.Document(out_path)
 
-    assert result.paragraphs[1].runs[0].font.size.pt == 14
-    assert result.paragraphs[1].paragraph_format.line_spacing == 2
+    assert result.paragraphs[0].runs[0].font.size.pt == 14
+    assert result.paragraphs[0].paragraph_format.line_spacing == 2

--- a/tests/test_extra_spaces.py
+++ b/tests/test_extra_spaces.py
@@ -1,0 +1,32 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import journal_updater.journal_updater as ju
+from docx.enum.text import WD_BREAK
+
+
+def _build_doc():
+    doc = ju.Document()
+    p1 = doc.add_paragraph("Page 1  text")
+    br = p1.add_run()
+    br.add_break(WD_BREAK.PAGE)
+    doc.add_paragraph("Page 2  text")
+    return doc
+
+
+def test_detect_and_remove_extra_spaces_page_range():
+    doc = _build_doc()
+    ju.detect_and_remove_extra_spaces(doc, [1])
+    assert doc.paragraphs[0].text == "Page 1 text"
+    assert doc.paragraphs[1].text == "Page 2  text"
+
+    ju.detect_and_remove_extra_spaces(doc, [2])
+    assert doc.paragraphs[1].text == "Page 2 text"
+
+def test_map_pages_to_paragraphs():
+    doc = _build_doc()
+    pages = ju.map_pages_to_paragraphs(doc)
+    assert 1 in pages and 2 in pages
+    assert any(p.text.startswith("Page 1") for p in pages[1])
+    assert any(p.text.startswith("Page 2") for p in pages[2])


### PR DESCRIPTION
## Summary
- map paragraphs to pages using manual page break detection
- restrict `detect_and_remove_extra_spaces` to only paragraphs from provided pages
- adjust journal update test and add dedicated test for extra space removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684302322e508321ad1020af3a8ee126