### PR TITLE
Refactor delete_after_page and update tests

### DIFF
--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -274,21 +274,18 @@ def load_instructions(content_path: Path) -> dict:
 
 
 def delete_after_page(doc: Document, page_number: int) -> None:
-    """Remove all content after the paragraph containing ``Page {page_number}``."""
-    search = f"Page {page_number}"
-    target = None
-    for p in doc.paragraphs:
-        if search in p.text:
-            target = p
-            break
-    if target is None:
-        return
-    body = target._element.getparent()
-    elem = target._element.getnext()
-    while elem is not None:
-        next_elem = elem.getnext()
-        body.remove(elem)
-        elem = next_elem
+    """Remove all content after the specified ``page_number``."""
+
+    pages = map_pages_to_paragraphs(doc)
+    to_remove: List['Paragraph'] = []
+    for num, paragraphs in pages.items():
+        if num > page_number:
+            to_remove.extend(paragraphs)
+
+    for p in reversed(to_remove):
+        elem = p._element
+        parent = elem.getparent()
+        parent.remove(elem)
 
 
 def apply_basic_formatting(doc: Document, font_size: Optional[int], line_spacing: Optional[float]) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -98,5 +98,5 @@ def test_format_front_and_footer(tmp_path):
     footer_p.text = "footer"
 
     journal_updater.format_front_and_footer(doc, font_size=13, line_spacing=1.25)
-    assert result.paragraphs[0].runs[0].font.size.pt == 14
-    assert result.paragraphs[0].paragraph_format.line_spacing == 2
+    assert doc.paragraphs[0].runs[0].font.size.pt == 13
+    assert doc.paragraphs[0].paragraph_format.line_spacing == 1.25

--- a/tests/test_delete_after_page.py
+++ b/tests/test_delete_after_page.py
@@ -1,26 +1,18 @@
 import sys
 import os
-import json
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import journal_updater.journal_updater as ju
+from docx.enum.text import WD_BREAK
 
 
-def test_delete_after_page(tmp_path):
-    base_path = tmp_path / "base.docx"
-    base = ju.Document()
-    base.add_paragraph("Volume 1, Issue 3")
-    base.add_paragraph("Old text")
-    base.save(base_path)
+def test_delete_after_page():
+    doc = ju.Document()
+    first = doc.add_paragraph("Keep this")
+    first.add_run().add_break(WD_BREAK.PAGE)
+    doc.add_paragraph("Remove")
 
-    content_dir = tmp_path / "content"
-    content_dir.mkdir()
-    (content_dir / "instructions.json").write_text(json.dumps({"delete_after_page": 1}))
+    ju.delete_after_page(doc, 1)
 
-    out_path = tmp_path / "out.docx"
-    ju.update_journal(base_path, content_dir, out_path, "1", "1", "June 2025", "Updates", 1, 2)
-
-    result = ju.Document(out_path)
-    texts = [p.text for p in result.paragraphs]
-    assert len(texts) == 1
-    assert "Page 1" in texts[0]
+    texts = [p.text for p in doc.paragraphs]
+    assert texts == ["Keep this"]


### PR DESCRIPTION
## Summary
- detect pages using `map_pages_to_paragraphs` inside `delete_after_page`
- revise the delete-after-page test for new behaviour
- fix `format_front_and_footer` test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430b62f8f48321aa5917e8a64298a6