### PR TITLE
Handle article files case-insensitively

### DIFF
--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import logging
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
@@ -301,6 +302,21 @@ def apply_basic_formatting(doc: Document, font_size: Optional[int], line_spacing
 def append_article(doc: Document, article_doc: Document):
     for element in article_doc.element.body:
         doc.element.body.append(element)
+
+
+def find_article_files(content_path: Path) -> List[Path]:
+    """Return article files matching ``article*.docx`` case-insensitively."""
+    pattern = "article"
+    files = sorted(
+        p
+        for p in content_path.iterdir()
+        if p.is_file() and p.name.lower().startswith(pattern) and p.suffix.lower() == ".docx"
+    )
+    if not files:
+        logging.warning(
+            "No article files found matching '%s*.docx' in %s", pattern, content_path
+        )
+    return files
 
 
 def map_pages_to_paragraphs(doc: Document) -> Dict[int, List['Paragraph']]:
@@ -769,7 +785,7 @@ def update_journal(
     clear_articles(doc)
 
     start_idx = len(doc.paragraphs)
-    for article_file in sorted(content_path.glob("article*.docx")):
+    for article_file in find_article_files(content_path):
         article_doc = Document(article_file)
         append_article(doc, article_doc)
     if "font_size" in instructions:

--- a/tests/test_article_files.py
+++ b/tests/test_article_files.py
@@ -1,0 +1,39 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import journal_updater.journal_updater as ju
+
+
+def test_update_journal_appends_articles(tmp_path):
+    base = ju.Document()
+    base.add_paragraph("ARTICLES")
+    base_path = tmp_path / "base.docx"
+    base.save(base_path)
+
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+
+    art1 = ju.Document()
+    art1.add_paragraph("First article")
+    art1.save(content_dir / "Article1.docx")
+
+    art2 = ju.Document()
+    art2.add_paragraph("Second article")
+    art2.save(content_dir / "article2.DOCX")
+
+    out_path = tmp_path / "out.docx"
+    ju.update_journal(
+        base_path,
+        content_dir,
+        out_path,
+        "1",
+        "1",
+        "June 2025",
+        "Articles",
+    )
+
+    result = ju.Document(out_path)
+    texts = [p.text for p in result.paragraphs]
+    assert "First article" in texts
+    assert "Second article" in texts


### PR DESCRIPTION
## Summary
- make article lookup case-insensitive
- warn when no article documents are found
- test update_journal with multiple article files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684321973368832194aacd6edbcad6de