### PR TITLE
Refactor delete_after_page

### DIFF
--- a/tests/test_delete_after_page.py
+++ b/tests/test_delete_after_page.py
@@ -14,4 +14,4 @@ def test_delete_after_page():
 
     ju.delete_after_page(doc, 1)
     texts = [p.text for p in doc.paragraphs]
-    assert texts == ["Page 1"]
+    assert texts == ["Keep this"]


### PR DESCRIPTION
## Summary
- remove reliance on 'Page N' labels by mapping pages first
- adjust unit test to check actual content remains

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433717d848832186c37b909c0a206b