### PR TITLE
Extend GUI with font options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ python -m journal_updater.gui
 
 The window lets you choose the base DOCX, the content folder, and where the
 output should be saved. It also collects the volume, issue, date and the page
-numbers used for the cover and where new articles should start. Clicking **Run Update**
-performs the same steps as the command line script.
+numbers used for the cover and where new articles should start. Additional
+fields let you enter a default font size, line spacing and font family. These
+settings are written to an `instructions.json` file in the selected content
+folder. Clicking **Run Update** performs the same steps as the command line
+script.
 ## Usage
 
 ```

--- a/journal_updater/gui.py
+++ b/journal_updater/gui.py
@@ -20,6 +20,9 @@ def run_gui():
     month_year = tk.StringVar()
     cover_page = tk.IntVar(value=1)
     start_page = tk.IntVar(value=3)
+    font_size = tk.StringVar()
+    line_spacing = tk.StringVar()
+    font_family = tk.StringVar()
 
     def choose_base():
         path = filedialog.askopenfilename(
@@ -68,6 +71,9 @@ def run_gui():
             return
         try:
             output_arg = Path(selected_output.get()) if selected_output.get() else None
+            fs = int(font_size.get()) if font_size.get() else None
+            ls = float(line_spacing.get()) if line_spacing.get() else None
+            ff = font_family.get() or None
             journal_updater.main_from_gui(
                 Path(selected_base.get()),
                 Path(selected_content.get()),
@@ -78,6 +84,9 @@ def run_gui():
                 cover_page.get(),
                 start_page.get(),
                 [Path(p) for p in selected_articles] if selected_articles else None,
+                font_size=fs,
+                line_spacing=ls,
+                font_family=ff,
             )
         except Exception as e:
             messagebox.showerror("Error", f"Failed to update journal: {e}")
@@ -129,6 +138,15 @@ def run_gui():
     row += 1
     tk.Label(frm, text="Start Page #:").grid(row=row, column=0, sticky="e")
     tk.Entry(frm, textvariable=start_page).grid(row=row, column=1, sticky="ew")
+    row += 1
+    tk.Label(frm, text="Font Size:").grid(row=row, column=0, sticky="e")
+    tk.Entry(frm, textvariable=font_size).grid(row=row, column=1, sticky="ew")
+    row += 1
+    tk.Label(frm, text="Line Spacing:").grid(row=row, column=0, sticky="e")
+    tk.Entry(frm, textvariable=line_spacing).grid(row=row, column=1, sticky="ew")
+    row += 1
+    tk.Label(frm, text="Font Family:").grid(row=row, column=0, sticky="e")
+    tk.Entry(frm, textvariable=font_family).grid(row=row, column=1, sticky="ew")
     row += 1
 
     tk.Button(frm, text="Run Update", command=run_update).grid(

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -946,8 +946,29 @@ def main_from_gui(
     cover_page_num: int = 1,
     start_page: Optional[int] = None,
     article_files: Optional[List[Path]] = None,
+    font_size: Optional[int] = None,
+    line_spacing: Optional[float] = None,
+    font_family: Optional[str] = None,
 ) -> None:
     """Helper for GUI front-end."""
+    inst_file = content_folder / "instructions.json"
+    instructions = {}
+    if inst_file.exists():
+        try:
+            with inst_file.open("r", encoding="utf-8") as f:
+                instructions = json.load(f)
+        except Exception:
+            instructions = {}
+    if font_size is not None:
+        instructions["font_size"] = font_size
+    if line_spacing is not None:
+        instructions["line_spacing"] = line_spacing
+    if font_family is not None:
+        instructions["font_family"] = font_family
+    if instructions:
+        with inst_file.open("w", encoding="utf-8") as f:
+            json.dump(instructions, f)
+
     update_journal(
         base_doc,
         content_folder,

--- a/tests/test_main_from_gui.py
+++ b/tests/test_main_from_gui.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -54,3 +55,39 @@ def test_main_from_gui(tmp_path):
     assert "Volume 2, Issue 3" in texts[0]
     assert "New Article Body" in texts
     assert "Old Article" not in texts
+
+
+def test_main_from_gui_font_options(tmp_path):
+    base_path = tmp_path / "base.docx"
+    _build_old_journal(base_path)
+
+    content = tmp_path / "content"
+    content.mkdir()
+    _build_blank_article(content / "article1.docx")
+
+    out_path = tmp_path / "out.docx"
+
+    ju.main_from_gui(
+        base_path,
+        content,
+        out_path,
+        volume="2",
+        issue="3",
+        month_year="July 2025",
+        cover_page_num=1,
+        start_page=3,
+        font_size=14,
+        line_spacing=1.5,
+        font_family="Arial",
+    )
+
+    inst = json.load((content / "instructions.json").open())
+    assert inst["font_size"] == 14
+    assert inst["line_spacing"] == 1.5
+    assert inst["font_family"] == "Arial"
+
+    result = ju.Document(out_path)
+    para = next(p for p in result.paragraphs if "New Article Body" in p.text)
+    assert para.runs[0].font.size.pt == 14
+    assert para.paragraph_format.line_spacing == 1.5
+    assert para.runs[0].font.name == "Arial"


### PR DESCRIPTION
## Summary
- add font size, line spacing and font family fields to GUI
- create/update `instructions.json` in `main_from_gui`
- pass font settings through to `update_journal`
- document GUI options in README
- test GUI propagation of font settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684337196de08321815fe57b666eb903