### PR TITLE
Implement editorial truncation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ An optional `instructions.json` file may be placed in the content folder to cont
 - `volume` – volume number for the issue.
 - `issue` – issue number.
 - `delete_after_page` – remove all content after this page number.
+- `delete_after_editorial` – remove all content after the last editorial page.
+- `cleanup_black_lines` – remove duplicate separation lines on each page.
 - `font_size` – default font size to apply to all text (in points).
 - `line_spacing` – line spacing value (e.g. `1.0` or `1.15`).
 - `font_family` – default font family name to apply across the document.
@@ -88,6 +90,8 @@ Example file:
   "volume": "2",
   "issue": "3",
   "delete_after_page": 2,
+  "delete_after_editorial": false,
+  "cleanup_black_lines": true,
   "font_size": 10,
   "line_spacing": 1.0,
   "font_family": "Times New Roman",

--- a/instructions.json
+++ b/instructions.json
@@ -2,5 +2,7 @@
   "font_size": 12,
   "line_spacing": 1.5,
   "delete_after_page": 1,
-  "font_family": "Times New Roman"
+  "font_family": "Times New Roman",
+  "delete_after_editorial": false,
+  "cleanup_black_lines": false
 }


### PR DESCRIPTION
## Summary
- add helper functions for removing pages after the last editorial and cleaning up extra horizontal lines
- update `update_journal` to support these new options from `instructions.json`
- document new `delete_after_editorial` and `cleanup_black_lines` keys
- expand example `instructions.json` with new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848336e55d8832193e4feeed36a29f8