### PR TITLE
Add center rule option to page borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Many helper functions are provided so that future automation steps can call them
 individually (e.g. `update_front_cover`, `update_page2_header`, `clear_articles`,
 and more). Most advanced operations are currently placeholders but documented
 for future work.
-Recent additions provide helpers for formatting the front cover and centering footer text across all sections.
+Recent additions provide helpers for formatting the front cover, centering
+footer text across all sections and adding optional page center lines with
+`add_page_borders_with_rule`.
 
 For non‑technical users a small Tkinter GUI is provided. Launch it with:
 
@@ -58,6 +60,7 @@ The script performs a handful of automated replacements:
    alongside it (requires `docx2pdf`).
 7. Applies optional front-cover formatting.
 8. Centers the footer layout across all pages.
+9. Inserts a vertical center rule when using `add_page_borders_with_rule`.
 
 Ensure your base document includes a Table of Contents with an
 **ARTICLES** heading so article titles can be detected and removed.

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -832,6 +832,46 @@ def add_page_borders(doc: Document, start_section: int) -> None:
         sectPr.append(pgBorders)
 
 
+def add_page_borders_with_rule(
+    doc: Document, start_section: int, add_center_line: bool = False
+) -> None:
+    """Add left/right borders and optionally a vertical center line.
+
+    When ``add_center_line`` is ``True`` a vertical line shape is inserted
+    into the header of each section starting at ``start_section``.
+    """
+
+    add_page_borders(doc, start_section)
+
+    if not add_center_line:
+        return
+
+    try:
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import nsmap
+    except Exception:
+        return
+
+    nsmap.setdefault("v", "urn:schemas-microsoft-com:vml")
+
+    for idx, section in enumerate(doc.sections):
+        if idx < start_section:
+            continue
+
+        header = section.header
+        paragraph = header.add_paragraph()
+        run = paragraph.add_run()
+        pict = OxmlElement("w:pict")
+        shape = OxmlElement("v:shape")
+        shape.set(
+            "style",
+            "position:absolute;left:50%;top:0;width:0;height:100%;"
+            "border-left:1pt solid black",
+        )
+        pict.append(shape)
+        run._r.append(pict)
+
+
 def apply_footer_layout(doc: Document, volume: str, issue: str, year: str) -> None:
     """Add standardized footers and leave the first page blank."""
 

--- a/tests/test_page_borders_center_line.py
+++ b/tests/test_page_borders_center_line.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from journal_updater import journal_updater as ju
+from docx.oxml.ns import qn
+
+
+def test_add_page_borders_with_center_line():
+    doc = ju.Document()
+    ju.add_page_borders_with_rule(doc, 0, add_center_line=True)
+
+    header_el = doc.sections[0].header._element
+    shapes = header_el.findall('.//' + qn('v:shape'))
+    assert len(shapes) == 1


### PR DESCRIPTION
## Summary
- allow drawing a vertical rule at the page center via `add_page_borders_with_rule`
- test new helper
- document option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684836ab00808321b2c83bef85b23b75