### PR TITLE
Ensure borders cleared after page deletion

### DIFF
--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -994,7 +994,26 @@ def update_journal(
     insert_presidents_message(doc, content_path / "president.jpg", message_text)
 
     if start_page is not None:
-        start_idx = remove_pages_from(doc, start_page)
+        delete_after_page(doc, start_page)
+        start_idx = len(doc.paragraphs)
+        try:
+            from docx.oxml.ns import qn
+        except Exception:
+            qn = None
+        for section in doc.sections:
+            ps = getattr(section, "page_setup", None)
+            if ps is not None and hasattr(ps, "left_border"):
+                try:
+                    ps.left_border = None
+                    ps.right_border = None
+                    ps.top_border = None
+                    ps.bottom_border = None
+                except Exception:
+                    pass
+            if qn is not None:
+                sectPr = section._sectPr
+                for b in list(sectPr.findall(qn("w:pgBorders"))):
+                    sectPr.remove(b)
         if start_idx == len(doc.paragraphs):
             clear_articles_preserve_editorials(doc)
             start_idx = len(doc.paragraphs)

--- a/tests/test_delete_after_page.py
+++ b/tests/test_delete_after_page.py
@@ -6,12 +6,34 @@ import journal_updater.journal_updater as ju
 from docx.enum.text import WD_BREAK
 
 
-def test_delete_after_page():
-    doc = ju.Document()
-    first = doc.add_paragraph("Keep this")
+def test_delete_after_page(tmp_path):
+    base = ju.Document()
+    first = base.add_paragraph("Keep this")
     first.add_run().add_break(WD_BREAK.PAGE)
-    doc.add_paragraph("Remove")
+    base.add_paragraph("Remove")
+    ju.add_page_borders(base, 0)
 
-    ju.delete_after_page(doc, 1)
-    texts = [p.text for p in doc.paragraphs]
+    base_path = tmp_path / "base.docx"
+    base.save(base_path)
+
+    content = tmp_path / "content"
+    content.mkdir()
+
+    out_path = tmp_path / "out.docx"
+    ju.update_journal(
+        base_path,
+        content,
+        out_path,
+        volume="1",
+        issue="1",
+        month_year="June 2025",
+        start_page=1,
+    )
+
+    result = ju.Document(out_path)
+    texts = [p.text for p in result.paragraphs]
     assert texts == ["Keep this"]
+
+    from docx.oxml.ns import qn
+
+    assert not list(result.sections[0]._sectPr.findall(qn("w:pgBorders")))


### PR DESCRIPTION
## Summary
- call `delete_after_page` when a starting page is set
- clear page borders after removing pages
- test that borders disappear after page deletion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684836853d988321b62715a4f2515bb1