### PR TITLE
Add optional center rule to page borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ individually (e.g. `update_front_cover`, `update_page2_header`, `clear_articles`
 and more). Most advanced operations are currently placeholders but documented
 for future work.
 Recent additions provide helpers for formatting the front cover and centering footer text across all sections.
+An additional helper `add_page_borders_with_rule(doc, start_section, add_center_line=False)`
+adds left and right borders and can optionally draw a vertical rule down the center of each page.
 
 For non‑technical users a small Tkinter GUI is provided. Launch it with:
 

--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -853,6 +853,36 @@ def add_page_borders(doc: Document, start_section: int) -> None:
         sectPr.append(pgBorders)
 
 
+def add_page_borders_with_rule(
+    doc: Document, start_section: int, add_center_line: bool = False
+) -> None:
+    """Add borders and optionally a vertical rule at the page center."""
+
+    add_page_borders(doc, start_section)
+
+    if not add_center_line:
+        return
+
+    try:
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+    except Exception:
+        return
+
+    for idx, section in enumerate(doc.sections):
+        if idx < start_section:
+            continue
+
+        header = section.header
+        paragraph = header.add_paragraph()
+        pict = OxmlElement("w:pict")
+        shape = OxmlElement("w:shape")
+        shape.set(qn("w:id"), f"center_rule_{idx}")
+        shape.set(qn("w:style"), "position:absolute;left:50%;top:0;width:0;height:100%")
+        pict.append(shape)
+        paragraph._p.append(pict)
+
+
 def apply_footer_layout(doc: Document, volume: str, issue: str, year: str) -> None:
     """Add standardized footers and leave the first page blank."""
 

--- a/tests/test_page_borders_center_rule.py
+++ b/tests/test_page_borders_center_rule.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from journal_updater import journal_updater as ju
+
+
+def test_add_page_borders_with_rule(tmp_path):
+    doc = ju.Document()
+    ju.add_page_borders_with_rule(doc, 0, add_center_line=True)
+
+    from docx.oxml.ns import qn
+
+    shapes = list(doc.sections[0].header._element.findall('.//' + qn('w:shape')))
+    assert len(shapes) == 1


### PR DESCRIPTION
## Summary
- support drawing a vertical center rule when adding page borders
- test new helper
- document the option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684837e10b74832190f116f1de33661f