### PR TITLE
Add import_articles helper for sorted import

### DIFF
--- a/journal_updater/journal_updater.py
+++ b/journal_updater/journal_updater.py
@@ -448,6 +448,30 @@ def append_article(doc: Document, article_doc: Document):
         doc.element.body.append(element)
 
 
+def import_articles(doc: Document, paths: List[Path]) -> None:
+    """Append articles from ``paths`` into ``doc`` after cleaning headers."""
+    paths = sorted(paths, key=lambda p: p.name.lower())
+    for path in paths:
+        article_doc = Document(path)
+        for section in article_doc.sections:
+            header = section.header
+            footer = section.footer
+            for p in list(header.paragraphs):
+                p._element.getparent().remove(p._element)
+            for p in list(footer.paragraphs):
+                p._element.getparent().remove(p._element)
+            sectPr = section._sectPr
+            try:
+                from docx.oxml.ns import qn
+
+                for tag in ("headerReference", "footerReference"):
+                    for ref in sectPr.findall(qn(f"w:{tag}")):
+                        sectPr.remove(ref)
+            except Exception:
+                pass
+        append_article(doc, article_doc)
+
+
 def find_article_files(content_path: Path) -> List[Path]:
     """Return article files matching ``article*.docx`` case-insensitively."""
     pattern = "article"
@@ -1004,9 +1028,7 @@ def update_journal(
     files = (
         article_files if article_files is not None else find_article_files(content_path)
     )
-    for article_file in files:
-        article_doc = Document(article_file)
-        append_article(doc, article_doc)
+    import_articles(doc, files)
     if "font_size" in instructions:
         set_font_size(doc, start_idx, int(instructions["font_size"]))
     if "line_spacing" in instructions:

--- a/tests/test_article_files.py
+++ b/tests/test_article_files.py
@@ -7,6 +7,7 @@ import journal_updater.journal_updater as ju
 
 def test_update_journal_appends_articles(tmp_path):
     base = ju.Document()
+    base.sections[0].header.paragraphs[0].text = "Base header"
     base.add_paragraph("ARTICLES")
     base_path = tmp_path / "base.docx"
     base.save(base_path)
@@ -15,12 +16,16 @@ def test_update_journal_appends_articles(tmp_path):
     content_dir.mkdir()
 
     art1 = ju.Document()
-    art1.add_paragraph("First article")
-    art1.save(content_dir / "Article1.docx")
+    art1.sections[0].header.paragraphs[0].text = "H2"
+    art1.sections[0].footer.paragraphs[0].text = "F2"
+    art1.add_paragraph("Second article")
+    art1.save(content_dir / "articleB.docx")
 
     art2 = ju.Document()
-    art2.add_paragraph("Second article")
-    art2.save(content_dir / "article2.DOCX")
+    art2.sections[0].header.paragraphs[0].text = "H1"
+    art2.sections[0].footer.paragraphs[0].text = "F1"
+    art2.add_paragraph("First article")
+    art2.save(content_dir / "articleA.docx")
 
     out_path = tmp_path / "out.docx"
     ju.update_journal(
@@ -34,5 +39,42 @@ def test_update_journal_appends_articles(tmp_path):
 
     result = ju.Document(out_path)
     texts = [p.text for p in result.paragraphs]
-    assert "First article" in texts
-    assert "Second article" in texts
+    first_index = texts.index("First article")
+    second_index = texts.index("Second article")
+    assert first_index < second_index
+    headers = [p.text for s in result.sections for p in s.header.paragraphs]
+    footers = [p.text for s in result.sections for p in s.footer.paragraphs]
+    assert "H1" not in headers and "H2" not in headers
+    assert "F1" not in footers and "F2" not in footers
+
+
+def test_import_articles_sorted_and_clean(tmp_path):
+    doc = ju.Document()
+    doc.sections[0].header.paragraphs[0].text = "Base"
+    doc.add_paragraph("Start")
+
+    art_b = ju.Document()
+    art_b.sections[0].header.paragraphs[0].text = "HB"
+    art_b.sections[0].footer.paragraphs[0].text = "FB"
+    art_b.add_paragraph("Second")
+    path_b = tmp_path / "b.docx"
+    art_b.save(path_b)
+
+    art_a = ju.Document()
+    art_a.sections[0].header.paragraphs[0].text = "HA"
+    art_a.sections[0].footer.paragraphs[0].text = "FA"
+    art_a.add_paragraph("First")
+    path_a = tmp_path / "a.docx"
+    art_a.save(path_a)
+
+    ju.import_articles(doc, [path_b, path_a])
+
+    out = tmp_path / "result.docx"
+    doc.save(out)
+    result = ju.Document(out)
+    texts = [p.text for p in result.paragraphs]
+    assert texts[1:] == ["First", "Second"]
+    headers = [p.text for s in result.sections for p in s.header.paragraphs]
+    footers = [p.text for s in result.sections for p in s.footer.paragraphs]
+    assert "HA" not in headers and "HB" not in headers
+    assert "FA" not in footers and "FB" not in footers


### PR DESCRIPTION
## Summary
- implement `import_articles` to import article files in sorted order while stripping headers and footers
- use new helper in `update_journal`
- test article import ordering and header/footer removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848364da4f48321bc477a85e38cfeb5